### PR TITLE
Remove source field from entity item

### DIFF
--- a/perceval/backends/pontoon/pontoon.py
+++ b/perceval/backends/pontoon/pontoon.py
@@ -260,6 +260,7 @@ class PontoonClient(HttpClient):
                 eprocessed.append(entity['pk'])
                 entity['history_data'] = self.history(entity['pk'], locale)
                 entity['locale'] = locale
+                entity.pop('source', None)
                 yield entity
 
             if not data['has_next'] or not data['entities']:

--- a/releases/unreleased/source-field-removed-from-the-output-item.yml
+++ b/releases/unreleased/source-field-removed-from-the-output-item.yml
@@ -1,0 +1,11 @@
+---
+title: Source field removed from the output item
+category: removed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Remove the `source` field from the entity item. It could
+  contain an empty list, a list of lists or a dictionary,
+  which causes errors in ElasticSearch when trying to insert
+  this item in the raw.
+


### PR DESCRIPTION
This PR removes the `source` field from the entity item. It could contain an empty list, a list of lists or a dictionary, which causes errors in ElasticSearch when trying to insert this item in the raw.