### PR TITLE
[pontoon] Add Personal Access Token (Bearer) authentication

### DIFF
--- a/perceval/backends/pontoon/pontoon.py
+++ b/perceval/backends/pontoon/pontoon.py
@@ -67,8 +67,8 @@ class Pontoon(Backend):
     DATE_FIELD = 'date_created'
     ENTITY_ID_FIELD = 'pk'
 
-    def __init__(self, uri, locale=None, project=None, session_id=None, tag=None, archive=None,
-                 max_items=MAX_ITEMS_PER_PAGE, ssl_verify=True):
+    def __init__(self, uri, locale=None, project=None, session_id=None, api_token=None,
+                 tag=None, archive=None, max_items=MAX_ITEMS_PER_PAGE, ssl_verify=True):
         if locale:
             origin = urijoin(uri, locale)
         elif project:
@@ -82,6 +82,7 @@ class Pontoon(Backend):
         self.locale = locale
         self.project = project
         self.session_id = session_id
+        self.api_token = api_token
         self.max_items = max_items
 
         self.client = None
@@ -214,7 +215,8 @@ class Pontoon(Backend):
     def _init_client(self, from_archive=False):
         """Init client"""
 
-        return PontoonClient(base_uri=self.uri, session_id=self.session_id, max_items=self.max_items)
+        return PontoonClient(base_uri=self.uri, session_id=self.session_id,
+                             api_token=self.api_token, max_items=self.max_items)
 
 
 class PontoonClient(HttpClient):
@@ -238,12 +240,17 @@ class PontoonClient(HttpClient):
     }
     """
 
-    def __init__(self, base_uri, session_id=None, max_items=MAX_ITEMS_PER_PAGE):
+    def __init__(self, base_uri, session_id=None, api_token=None, max_items=MAX_ITEMS_PER_PAGE):
         self.max_items = max_items
         self.session_id = session_id
+        self.api_token = api_token
 
         headers = {'x-requested-with': 'XMLHttpRequest'}
-        if session_id:
+        # A Pontoon Personal Access Token (Authorization: Bearer) supersedes the
+        # session cookie and avoids its ~14-day expiry (see mozilla/pontoon#4081).
+        if api_token:
+            headers['Authorization'] = f"Bearer {api_token}"
+        elif session_id:
             headers['Cookie'] = f"sessionid={session_id}"
         super().__init__(base_url=base_uri, extra_headers=headers)
 
@@ -371,5 +378,8 @@ class PontoonCommand(BackendCommand):
                            help="Project to fetch.")
         group.add_argument('--session-id', dest='session_id', type=str,
                            help="Django session ID to use for user-actions requests.")
+        group.add_argument('--api-token', dest='api_token', type=str,
+                           help="Pontoon Personal Access Token (Bearer) for API requests; "
+                                "preferred over --session-id (no ~14-day expiry).")
 
         return parser

--- a/releases/unreleased/pontoon-api-token-auth.yml
+++ b/releases/unreleased/pontoon-api-token-auth.yml
@@ -1,0 +1,10 @@
+title: Support Pontoon Personal Access Token (Bearer) authentication
+category: added
+author: Arron Atchison <aatchison@thunderbird.net>
+notes: >
+    The Pontoon backend can now authenticate to the API with a Personal
+    Access Token via the Authorization: Bearer header (new --api-token /
+    api_token option), in addition to the Django session cookie. Pontoon
+    PATs do not suffer the session cookie's ~14-day expiry (they last 365
+    days), so token auth is preferred for unattended collection. When set,
+    the token supersedes the session id.

--- a/tests/test_pontoon.py
+++ b/tests/test_pontoon.py
@@ -541,6 +541,27 @@ class TestPontoonClient(unittest.TestCase):
         self.assertEqual(http_requests[2].path, '/api/v2/user-actions/2024-12-04/project/p1/')
         self.assertEqual(http_requests[2].headers['Cookie'], 'sessionid=foobar')
 
+    @httpretty.activate
+    def test_actions_with_api_token(self):
+        """Test that api_token sends a Bearer Authorization header (not a cookie)"""
+
+        # Mock HTTP server
+        setup_actions_http_server()
+
+        client = PontoonClient(base_uri=PONTOON_URL,
+                               api_token='tok123',
+                               max_items=5)
+
+        from_date = datetime.datetime(2024, 12, 2)
+        to_date = datetime.datetime(2024, 12, 4)
+        _ = [e for e in client.user_actions(project='p1', from_date=from_date, to_date=to_date)]
+
+        http_requests = httpretty.latest_requests()
+        self.assertGreater(len(http_requests), 0)
+        # Authenticates with a Pontoon PAT via the Authorization header, not a session cookie
+        self.assertEqual(http_requests[0].headers['Authorization'], 'Bearer tok123')
+        self.assertNotIn('Cookie', http_requests[0].headers)
+
 
 if __name__ == "__main__":
     unittest.main(warnings='ignore')


### PR DESCRIPTION
## Problem
The Pontoon backend authenticates only with a Django `sessionid` cookie (`--session-id`). That cookie **expires ~every 14 days**, which silently breaks unattended collection — every request then returns **403 Forbidden** and the cursor stalls.

## Change
[mozilla/pontoon#4081](https://github.com/mozilla/pontoon/pull/4081) extended **Personal Access Token** auth (`Authorization: Bearer <token>`, **365-day** expiry) to all `/api/v2/` endpoints, including `user-actions`. This adds matching support to the backend:
- New `api_token` option + `--api-token` CLI arg, threaded into `PontoonClient`.
- When set, the client sends `Authorization: Bearer <token>` and **supersedes** the session cookie.
- Backwards compatible: `--session-id` still works when no token is given.

Adds `test_actions_with_api_token` (asserts the `Authorization: Bearer` header is sent and no session `Cookie`). Full `tests/test_pontoon.py` passes (17), flake8 clean, changelog entry included.

PATs avoid the recurring 14-day session expiry, so they're preferred for unattended collectors.